### PR TITLE
Catch onbeforeunload access errors

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -277,7 +277,15 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
 
             e.preventDefault();
 
-            var onBeforeUnloadText = typeof window.onbeforeunload === 'function' ? window.onbeforeunload() : '';
+            var onBeforeUnloadText = '';
+            if (typeof window.onbeforeunload === 'function') {
+                try {
+                    onBeforeUnloadText = window.onbeforeunload();
+                } catch(error) {
+                    var logWarn = (this.context.logger && this.context.logger.warn) || console.warn;
+                    logWarn('Warning: Call of window.onbeforeunload failed', error);
+                }
+            }
             var confirmResult = onBeforeUnloadText ? window.confirm(onBeforeUnloadText) : true;
 
             if (confirmResult) {

--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -60,7 +60,8 @@ function createComponent(Component, opts) {
 
     HistoryHandler.displayName = 'HistoryHandler';
     HistoryHandler.contextTypes = {
-        executeAction: PropTypes.func.isRequired
+        executeAction: PropTypes.func.isRequired,
+        logger: PropTypes.object
     };
     HistoryHandler.propTypes = {
         currentRoute: PropTypes.object,
@@ -162,7 +163,15 @@ function createComponent(Component, opts) {
 
             var currentUrl = currentRoute.url;
 
-            var onBeforeUnloadText = typeof window.onbeforeunload === 'function' ? window.onbeforeunload() : '';
+            var onBeforeUnloadText = '';
+            if (typeof window.onbeforeunload === 'function') {
+                try {
+                    onBeforeUnloadText = window.onbeforeunload();
+                } catch(error) {
+                    var logWarn = (this.context.logger && this.context.logger.warn) || console.warn;
+                    logWarn('Warning: Call of window.onbeforeunload failed', error);
+                }
+            }
             var confirmResult = onBeforeUnloadText ? window.confirm(onBeforeUnloadText) : true;
 
             var navParams = nav.params || {};

--- a/packages/fluxible-router/tests/mocks/MockAppComponent.js
+++ b/packages/fluxible-router/tests/mocks/MockAppComponent.js
@@ -32,7 +32,7 @@ module.exports = provideContext(handleHistory(MockAppComponent, {
 }), customContextTypes);
 
 module.exports.createWrappedMockAppComponent = function createWrappedMockAppComponent(opts) {
-    return provideContext(handleHistory(MockAppComponent, opts));
+    return provideContext(handleHistory(MockAppComponent, opts), customContextTypes);
 };
 
 module.exports.createDecoratedMockAppComponent = function createDecoratedMockAppComponent(opts) {

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -474,14 +474,12 @@ describe('NavLink', function () {
         });
 
         describe('window.onbeforeunload', function () {
-            beforeEach(function () {
+            it('should not call context.executeAction when a user does not confirm the onbeforeunload method', function (done) {
                 global.window.confirm = function () { return false; };
                 global.window.onbeforeunload = function () {
                     return 'this is a test';
                 };
-            });
 
-            it('should not call context.executeAction when a user does not confirm the onbeforeunload method', function (done) {
                 var link = ReactTestUtils.renderIntoDocument(
                     <MockAppComponent context={mockContext}>
                         <NavLink href='/foo' followLink={false} />
@@ -490,6 +488,31 @@ describe('NavLink', function () {
                 ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
                 window.setTimeout(function () {
                     expect(mockContext.executeActionCalls.length).to.equal(0);
+                    done();
+                }, 10);
+            });
+
+            it('should ignore any error which happens when calling onbeforeunload', function (done) {
+                var loggerWarning;
+                mockContext.logger = {
+                    warn: function () {
+                        loggerWarning = arguments;
+                    }
+                };
+                global.window.onbeforeunload = function () {
+                    throw new Error('Test error');
+                };
+
+                var link = ReactTestUtils.renderIntoDocument(
+                    <MockAppComponent context={mockContext}>
+                        <NavLink href='/foo' followLink={false} />
+                    </MockAppComponent>
+                );
+                ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
+                window.setTimeout(function () {
+                    expect(loggerWarning[0]).to.equal('Warning: Call of window.onbeforeunload failed');
+                    expect(loggerWarning[1].message).to.equal('Test error');
+                    expect(mockContext.executeActionCalls.length).to.equal(1);
                     done();
                 }, 10);
             });

--- a/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
+++ b/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
@@ -371,17 +371,19 @@ describe('handleHistory', function () {
                     });
                 });
                 describe('window.onbeforeunload', function () {
+                    var MockAppComponent;
                     beforeEach(function () {
+                        global.window.dispatchEvent(Object.assign(new Event('popstate'), {}));
+                        var routeStore = mockContext.getStore('RouteStore');
+                        routeStore._handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
+                    });
+
+                    it('does not execute navigate action if there is a window.onbeforeunload method that the user does not confirm', function (done) {
                         global.window.confirm = function () { return false; };
                         global.window.onbeforeunload = function () {
                             return 'this is a test';
                         };
-                    });
-
-                    it('does not dispatch navigate event if there is a window.onbeforeunload method that the user does not confirm', function (done) {
-                        var routeStore = mockContext.getStore('RouteStore');
-                        routeStore._handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
-                        var MockAppComponent = mockCreator({
+                        MockAppComponent = mockCreator({
                             historyCreator: function () {
                                 return historyMock('/foo');
                             }
@@ -390,7 +392,37 @@ describe('handleHistory', function () {
                             <MockAppComponent context={mockContext} />
                         );
                         window.setTimeout(function() {
-                            expect(testResult.dispatch).to.equal(undefined, JSON.stringify(testResult.dispatch));
+                            expect(testResult.pushState).to.have.length(1);
+                            expect(testResult.pushState[0].url).to.equal('/the_path_from_history');
+                            expect(mockContext.executeActionCalls.length).to.equal(0);
+                            done();
+                        }, 10);
+                    });
+
+                    it('should ignore any error which happens when calling onbeforeunload', function (done) {
+                        var loggerWarning;
+                        mockContext.logger = {
+                            warn: function () {
+                                loggerWarning = arguments;
+                            }
+                        };
+                        global.window.confirm = function () { return false; };
+                        global.window.onbeforeunload = function () {
+                            throw new Error('Test error');
+                        };
+                        MockAppComponent = mockCreator({
+                            historyCreator: function () {
+                                return historyMock('/foo');
+                            }
+                        });
+                        ReactTestUtils.renderIntoDocument(
+                            <MockAppComponent context={mockContext} />
+                        );
+                        window.setTimeout(function() {
+                            expect(loggerWarning[0]).to.equal('Warning: Call of window.onbeforeunload failed');
+                            expect(loggerWarning[1].message).to.equal('Test error');
+                            expect(testResult.pushState).to.equal(undefined);
+                            expect(mockContext.executeActionCalls.length).to.equal(1);
                             done();
                         }, 10);
                     });


### PR DESCRIPTION
In Firefox it could be forbidden to call onbeforeunload if it wasn't set by the page itself, e.g. set by plugins. When calling it, it will throw an Error with the message "Permission denied to access object". The result is, that client side navigation will not work anymore.
Since I couldn't find a possibility to check if the function is allowed to be called, I catch any execption and only log the error.

An example plugin which causes this issue:
https://github.com/tjhrulz/WebNowPlaying